### PR TITLE
Remove remaining markdown use from api/call.html template

### DIFF
--- a/formapi/templates/formapi/api/call.html
+++ b/formapi/templates/formapi/api/call.html
@@ -1,6 +1,5 @@
 {% extends 'formapi/base.html' %}
 {% load url from future %}
-{% load markup %}
 {% block content %}
     <div class="span8">
         <div class="hero-unit">
@@ -24,7 +23,7 @@
                 {% endfor %}
             </ul>
             <h4>Description</h4>
-            <p>{{ docstring|restructuredtext }}</p>
+            <p>{{ docstring }}</p>
 
         </div>
     </div>


### PR DESCRIPTION
A left-over "load markdown" tag, and use of its restructured-text filter on the docstring description were causing this view to fail since markdown dependency had been eliminated. This patch just prints the "docstring" value unformatted.
