### PR TITLE
Improved hash space and expressivity

### DIFF
--- a/formapi/api.py
+++ b/formapi/api.py
@@ -115,10 +115,13 @@ class API(FormView):
         return key, sign
 
     def sign_ok(self, sign):
-        digest = get_pairs_sign(secret=self.api_key.secret, sorted_pairs=self.normalized_parameters())
-        digest = prepare_uuid_string(digest)
-        sign = prepare_uuid_string(sign)
-        return constant_time_compare(sign, digest)
+        secure = len(sign) == 26
+        local = get_pairs_sign(secret=self.api_key.secret,
+                               sorted_pairs=self.normalized_parameters(),
+                               secure=secure)
+        if not secure:
+            sign = prepare_uuid_string(sign)
+        return constant_time_compare(sign, local)
 
     def normalized_parameters(self):
         """

--- a/formapi/migrations/0003_more_secure_key_secret.py
+++ b/formapi/migrations/0003_more_secure_key_secret.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'APIKey.secret'
+        db.alter_column('formapi_apikey', 'secret', self.gf('formapi.fields.KeyField')(max_length=32))
+
+        # Changing field 'APIKey.key'
+        db.alter_column('formapi_apikey', 'key', self.gf('formapi.fields.KeyField')(max_length=32))
+
+    def backwards(self, orm):
+
+        # Changing field 'APIKey.secret'
+        db.alter_column('formapi_apikey', 'secret', self.gf('formapi.fields.UUIDField')(max_length=32, unique=True))
+
+        # Changing field 'APIKey.key'
+        db.alter_column('formapi_apikey', 'key', self.gf('formapi.fields.UUIDField')(max_length=32, unique=True))
+
+    models = {
+        'formapi.apikey': {
+            'Meta': {'object_name': 'APIKey'},
+            'comment': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'default': "'SW6jrl31y_n01Kid'", 'unique': 'True', 'max_length': '16'}),
+            'revoked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'2ZZqP8MdpnqRtACcFieE9u3JcGE4MRKC'", 'unique': 'True', 'max_length': '32'}),
+            'test': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['formapi']

--- a/formapi/models.py
+++ b/formapi/models.py
@@ -1,12 +1,13 @@
 # coding=utf-8
+
 from django.db import models
-from .fields import UUIDField
+from .fields import KeyField
 
 
 class APIKey(models.Model):
     email = models.EmailField(blank=False, null=False)
-    key = UUIDField()
-    secret = UUIDField()
+    key = KeyField(max_length=32, generated_key_length=16, unique=True)
+    secret = KeyField(max_length=32, unique=True)
     comment = models.TextField(blank=True, null=True)
     revoked = models.BooleanField(default=False)
     test = models.BooleanField(default=False)
@@ -19,3 +20,4 @@ class APIKey(models.Model):
 
     def __unicode__(self):
         return u'API Key #%s' % self.id
+


### PR DESCRIPTION
Previously all random data came from Python’s built-in UUID4 encoded in
hexadecimal. Hexadecimal encodes 16 values in one byte, that means there
is a 4:8 ratio of meaningful bits to each byte of hexadecimal encoding.
Instead we use base64 which encodes at a 6:8 ratio. This has the added
benefit of looking better.
