### PR TITLE
Run against Django 1.11 + Minor fix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - 3.6-dev
+  - 3.6
 
 env:
   matrix:
@@ -19,6 +19,7 @@ env:
     - DJANGO=1.8
     - DJANGO=1.9
     - DJANGO=1.10
+    - DJANGO=1.11
 
 matrix:
   exclude:
@@ -30,6 +31,8 @@ matrix:
       env: DJANGO=1.9
     - python: 2.6
       env: DJANGO=1.10
+    - python: 2.6
+      env: DJANGO=1.11
 
     - python: 3.3
       env: DJANGO=1.3
@@ -39,6 +42,8 @@ matrix:
       env: DJANGO=1.9
     - python: 3.3
       env: DJANGO=1.10
+    - python: 3.3
+      env: DJANGO=1.11
 
     - python: 3.4
       env: DJANGO=1.3
@@ -60,15 +65,15 @@ matrix:
     - python: 3.5
       env: DJANGO=1.7
 
-    - python: 3.6-dev
+    - python: 3.6
       env: DJANGO=1.3
-    - python: 3.6-dev
+    - python: 3.6
       env: DJANGO=1.4
-    - python: 3.6-dev
+    - python: 3.6
       env: DJANGO=1.5
-    - python: 3.6-dev
+    - python: 3.6
       env: DJANGO=1.6
-    - python: 3.6-dev
+    - python: 3.6
       env: DJANGO=1.7
 
   include:

--- a/conftest.py
+++ b/conftest.py
@@ -31,7 +31,14 @@ def pytest_configure():
         TEMPLATE_DEBUG=True,
         TEMPLATES=[
             {'APP_DIRS': True,
-             'BACKEND': 'django.template.backends.django.DjangoTemplates'},
+             'BACKEND': 'django.template.backends.django.DjangoTemplates',
+             'OPTIONS': {
+                 'debug': True,
+                 'context_processors': [
+                     'django.contrib.auth.context_processors.auth',
+                     'django.template.context_processors.request',
+                 ]
+             }},
         ]
     )
 

--- a/formapi/admin.py
+++ b/formapi/admin.py
@@ -7,4 +7,5 @@ class APIKeyAdmin(admin.ModelAdmin):
     readonly_fields = ('key', 'secret')
     list_display = ('id', 'email', 'revoked', 'test', 'created')
 
+
 admin.site.register(APIKey, APIKeyAdmin)

--- a/formapi/api.py
+++ b/formapi/api.py
@@ -86,6 +86,7 @@ class DjangoJSONEncoder(JSONEncoder):
         elif isinstance(obj, datetime.timedelta):
             return obj.seconds
 
+
 dumps = curry(dumps, cls=DjangoJSONEncoder)
 
 

--- a/formapi/fields.py
+++ b/formapi/fields.py
@@ -42,6 +42,9 @@ class UUIDField(models.Field):
     def get_db_prep_value(self, value, connection, prepared=False):
         return prepare_uuid_string(value)
 
+    def from_db_value(self, value, expression, connection, context):
+        return prepare_uuid_string(value)
+
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
         return prepare_uuid_string(value, default='')

--- a/formapi/tests.py
+++ b/formapi/tests.py
@@ -15,7 +15,7 @@ from formapi.compat import smart_u, get_user_model
 from formapi.models import APIKey
 from formapi.utils import get_sign
 
-TOTAL_TESTS = 19
+TOTAL_TESTS = 20
 
 
 class SignedRequestTest(TransactionTestCase):
@@ -45,6 +45,17 @@ class SignedRequestTest(TransactionTestCase):
 
     def test_api_key(self):
         smart_u(self.api_key)
+
+    def test_api_key_gets_prepared_uuid_str_on_assignment(self):
+        from formapi.utils import prepare_uuid_string
+
+        # Intentionally get key again
+        test_key = APIKey.objects.get(email='test@example.com')
+
+        self.assertEqual(
+            test_key.key,
+            prepare_uuid_string(test_key.key)
+        )
 
     def test_valid_auth(self):
         response = self.send_request(self.authenticate_url, {'username': self.user.username, 'password': 'rosebud'})


### PR DESCRIPTION
In addition to running against 1.11, this fixes a small issue that affects Django1.9+ where the value of the custom UUIDField does not go through `formapi.utils.prepare_uuid_string` on retrieval, because Django [does not call `to_python` on assignment](https://docs.djangoproject.com/en/1.11/releases/1.8/#subfieldbase) after deprecating `SubfieldBase`. The fix is to also call `prepare_uuid_string` on `from_db_value` method of the field. The added test would fail on Django >= 1.9 without overriding `from_db_value`,

Not sure if it'd make more sense to use Django's own UUIDField with 1.8+ and override methods to call our `prepare_uuid_string`.